### PR TITLE
feat(onboarding): add multi-step onboarding flow on first install

### DIFF
--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -78,10 +78,20 @@ export default defineBackground(() => {
   }
 
   // Only register on install (first time or update)
-  browser.runtime.onInstalled.addListener(async () => {
+  browser.runtime.onInstalled.addListener(async (details) => {
     console.log('[Background] Extension installed/updated');
     await registerContentScripts();
     await reloadAllTabs();
+
+    // Open onboarding on first install only
+    if (details.reason === 'install') {
+      const stored = await browser.storage.local.get(['hasCompletedOnboarding']);
+      if (!stored.hasCompletedOnboarding) {
+        browser.tabs.create({
+          url: browser.runtime.getURL('/onboarding.html'),
+        });
+      }
+    }
   });
 
   // Also register immediately on background script load (for dev mode reload)

--- a/src/entrypoints/onboarding/App.svelte
+++ b/src/entrypoints/onboarding/App.svelte
@@ -1,0 +1,263 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { storage } from '#imports';
+  import Welcome from './steps/Welcome.svelte';
+  import Setup from './steps/Setup.svelte';
+  import Complete from './steps/Complete.svelte';
+
+  const hasCompletedOnboardingStorage = storage.defineItem<boolean>(
+    'local:hasCompletedOnboarding',
+    { fallback: false },
+  );
+
+  const darkModeStorage = storage.defineItem<boolean>('local:darkMode', {
+    fallback: false,
+  });
+
+  let currentStep = $state(1);
+  let darkMode = $state(false);
+
+  function goNext() {
+    if (currentStep < 3) currentStep++;
+  }
+
+  function goBack() {
+    if (currentStep > 1) currentStep--;
+  }
+
+  async function skipOnboarding() {
+    await hasCompletedOnboardingStorage.setValue(true);
+    window.close();
+  }
+
+  function applyTheme(isDark: boolean) {
+    document.documentElement.setAttribute('data-theme', isDark ? 'dark' : 'light');
+  }
+
+  async function toggleDarkMode() {
+    darkMode = !darkMode;
+    await darkModeStorage.setValue(darkMode);
+    applyTheme(darkMode);
+  }
+
+  onMount(async () => {
+    darkMode = (await darkModeStorage.getValue()) ?? false;
+    applyTheme(darkMode);
+
+    // If already completed, jump to final step
+    const completed = await hasCompletedOnboardingStorage.getValue();
+    if (completed) {
+      currentStep = 3;
+    }
+  });
+</script>
+
+<main>
+  <div class="top-bar">
+    <button
+      class="theme-toggle"
+      onclick={toggleDarkMode}
+      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+    >
+      {#if darkMode}
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <circle cx="12" cy="12" r="5" stroke="currentColor" stroke-width="2" />
+          <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+        </svg>
+        <span>Light</span>
+      {:else}
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+        <span>Dark</span>
+      {/if}
+    </button>
+  </div>
+
+  <div class="progress-bar">
+    {#each [1, 2, 3] as step}
+      <div class="progress-step" class:active={currentStep >= step} class:current={currentStep === step}>
+        <div class="step-dot">{step}</div>
+        <span class="step-label">
+          {#if step === 1}Welcome{:else if step === 2}Setup{:else}Ready{/if}
+        </span>
+      </div>
+      {#if step < 3}
+        <div class="progress-line" class:active={currentStep > step}></div>
+      {/if}
+    {/each}
+  </div>
+
+  <div class="step-container">
+    {#if currentStep === 1}
+      <Welcome onNext={goNext} onSkip={skipOnboarding} />
+    {:else if currentStep === 2}
+      <Setup onNext={goNext} onBack={goBack} onSkip={skipOnboarding} />
+    {:else}
+      <Complete />
+    {/if}
+  </div>
+</main>
+
+<style>
+  :global(:root) {
+    --st-bg: #ffffff;
+    --st-bg-secondary: #f5f5f5;
+    --st-bg-elevated: #ffffff;
+    --st-text: #000000;
+    --st-text-secondary: #737373;
+    --st-text-muted: #d4d4d4;
+    --st-border: #e5e5e5;
+    --st-brand: #6b16ed;
+    --st-brand-dark: #5a12c7;
+    --st-brand-surface: #f5f0ff;
+    --st-brand-surface-alt: #faf8ff;
+    --st-brand-text: #5a12c7;
+    --st-success: #22c55e;
+    --st-warning-surface: #fefce8;
+    --st-warning-border: #fde047;
+    --st-warning-text: #854d0e;
+    --st-shadow: rgba(0, 0, 0, 0.08);
+    --st-overlay: rgba(0, 0, 0, 0.3);
+    --st-focus-ring: #6b16ed;
+    --st-btn-bg: #6b16ed;
+    --st-btn-hover-bg: #5a12c7;
+    --st-btn-border: #6b16ed;
+    --st-select-arrow: url("data:image/svg+xml,%3Csvg width='12' height='12' viewBox='0 0 12 12' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M3 4.5L6 7.5L9 4.5' stroke='%23737373' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  }
+
+  :global(:root[data-theme='dark']) {
+    --st-bg: #1a1a1a;
+    --st-bg-secondary: #262626;
+    --st-bg-elevated: #2a2a2a;
+    --st-text: #e5e5e5;
+    --st-text-secondary: #a3a3a3;
+    --st-text-muted: #525252;
+    --st-border: #404040;
+    --st-brand: #8b5cf6;
+    --st-brand-dark: #7c3aed;
+    --st-brand-surface: #2d1b69;
+    --st-brand-surface-alt: #231554;
+    --st-brand-text: #c4b5fd;
+    --st-success: #4ade80;
+    --st-warning-surface: #422006;
+    --st-warning-border: #854d0e;
+    --st-warning-text: #fde047;
+    --st-shadow: rgba(0, 0, 0, 0.3);
+    --st-overlay: rgba(0, 0, 0, 0.5);
+    --st-focus-ring: #8b5cf6;
+    --st-btn-bg: #2d1b69;
+    --st-btn-hover-bg: #8b5cf6;
+    --st-btn-border: #8b5cf6;
+    --st-select-arrow: url("data:image/svg+xml,%3Csvg width='12' height='12' viewBox='0 0 12 12' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M3 4.5L6 7.5L9 4.5' stroke='%23a3a3a3' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  }
+
+  :global(html),
+  :global(body) {
+    background: var(--st-bg);
+  }
+
+  main {
+    width: 100%;
+    min-height: 100vh;
+    padding: 0;
+    font-family: Inter, -apple-system, BlinkMacSystemFont, sans-serif;
+    background: var(--st-bg);
+    color: var(--st-text);
+  }
+
+  .top-bar {
+    display: flex;
+    justify-content: flex-end;
+    padding: 16px 24px;
+  }
+
+  .theme-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: var(--st-bg-secondary);
+    border: 1px solid var(--st-border);
+    border-radius: 6px;
+    padding: 6px 12px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--st-text-secondary);
+    cursor: pointer;
+    transition: all 0.15s ease;
+  }
+
+  .theme-toggle:hover {
+    background: var(--st-bg-elevated);
+    color: var(--st-text);
+  }
+
+  .progress-bar {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 24px 32px;
+    gap: 0;
+  }
+
+  .progress-step {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .step-dot {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.75rem;
+    font-weight: 600;
+    background: var(--st-bg-secondary);
+    color: var(--st-text-muted);
+    border: 2px solid var(--st-border);
+    transition: all 0.2s ease;
+  }
+
+  .progress-step.active .step-dot {
+    background: var(--st-brand);
+    color: #fff;
+    border-color: var(--st-brand);
+  }
+
+  .progress-step.current .step-dot {
+    box-shadow: 0 0 0 3px var(--st-brand-surface);
+  }
+
+  .step-label {
+    font-size: 0.6875rem;
+    font-weight: 500;
+    color: var(--st-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .progress-step.active .step-label {
+    color: var(--st-text-secondary);
+  }
+
+  .progress-line {
+    width: 80px;
+    height: 2px;
+    background: var(--st-border);
+    margin: 0 8px;
+    margin-bottom: 20px;
+    transition: background 0.2s ease;
+  }
+
+  .progress-line.active {
+    background: var(--st-brand);
+  }
+
+  .step-container {
+    padding: 0 24px 40px;
+  }
+</style>

--- a/src/entrypoints/onboarding/app.css
+++ b/src/entrypoints/onboarding/app.css
@@ -1,0 +1,29 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family:
+    Inter,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    sans-serif;
+  background: var(--st-bg, #ffffff);
+  color: var(--st-text, #000);
+  font-size: 0.9375rem;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+#app {
+  width: 100%;
+  max-width: 640px;
+  min-height: 100vh;
+  background: var(--st-bg, #ffffff);
+  margin: 0 auto;
+}

--- a/src/entrypoints/onboarding/index.html
+++ b/src/entrypoints/onboarding/index.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Welcome to Safetyper</title>
+    <style>
+      body, html {
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        min-height: 100vh;
+        display: flex;
+        justify-content: center;
+        background: #ffffff;
+      }
+
+      html[data-theme='dark'],
+      html[data-theme='dark'] body {
+        background: #1a1a1a;
+      }
+
+      #app {
+        width: 100%;
+        max-width: 640px;
+        min-height: 100vh;
+        margin: 0 auto;
+      }
+    </style>
+    <script>
+      // Apply theme before paint to avoid white flash
+      var api = (typeof browser !== 'undefined' && browser.storage) || chrome.storage;
+      api.local.get(['darkMode'], function(result) {
+        if (result.darkMode) {
+          document.documentElement.setAttribute('data-theme', 'dark');
+        }
+      });
+    </script>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/src/entrypoints/onboarding/main.ts
+++ b/src/entrypoints/onboarding/main.ts
@@ -1,0 +1,10 @@
+import { mount } from 'svelte';
+import App from './App.svelte';
+import '~/assets/fonts/fonts.css';
+import './app.css';
+
+const app = mount(App, {
+  target: document.getElementById('app')!,
+});
+
+export default app;

--- a/src/entrypoints/onboarding/steps/Complete.svelte
+++ b/src/entrypoints/onboarding/steps/Complete.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+  function closeTab() {
+    window.close();
+  }
+</script>
+
+<div class="complete">
+  <div class="hero">
+    <div class="checkmark">
+      <svg width="40" height="40" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M20 6L9 17L4 12" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </div>
+    <h2>You're all set!</h2>
+    <p class="subtitle">Safetyper is ready to help you write better. Here's how to use it:</p>
+  </div>
+
+  <div class="steps">
+    <div class="usage-step">
+      <div class="step-number">1</div>
+      <div class="step-content">
+        <h3>Click into any text field</h3>
+        <p>Navigate to any website and click on a text input, textarea, or content-editable area.</p>
+      </div>
+    </div>
+
+    <div class="usage-step">
+      <div class="step-number">2</div>
+      <div class="step-content">
+        <h3>Start typing</h3>
+        <p>Write your text naturally. After a brief pause, the Safetyper icon will appear near your cursor.</p>
+      </div>
+    </div>
+
+    <div class="usage-step">
+      <div class="step-number">3</div>
+      <div class="step-content">
+        <h3>Review corrections</h3>
+        <p>Click the icon to see grammar and spelling suggestions. Accept or dismiss them with one click.</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="actions">
+    <button class="primary-btn" onclick={closeTab}>Close & Start Writing</button>
+  </div>
+</div>
+
+<style>
+  .complete {
+    max-width: 480px;
+    margin: 0 auto;
+    text-align: center;
+  }
+
+  .hero {
+    margin-bottom: 32px;
+  }
+
+  .checkmark {
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    background: var(--st-success);
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto 16px;
+  }
+
+  h2 {
+    font-size: 1.375rem;
+    font-weight: 700;
+    color: var(--st-text);
+    margin-bottom: 8px;
+  }
+
+  .subtitle {
+    font-size: 0.9375rem;
+    color: var(--st-text-secondary);
+  }
+
+  .steps {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-bottom: 32px;
+    text-align: left;
+  }
+
+  .usage-step {
+    display: flex;
+    gap: 14px;
+    align-items: flex-start;
+    padding: 16px;
+    background: var(--st-bg-secondary);
+    border: 1px solid var(--st-border);
+    border-radius: 10px;
+  }
+
+  .step-number {
+    flex-shrink: 0;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: var(--st-brand-surface);
+    color: var(--st-brand);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.8125rem;
+    font-weight: 700;
+  }
+
+  .step-content h3 {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--st-text);
+    margin-bottom: 4px;
+  }
+
+  .step-content p {
+    font-size: 0.8125rem;
+    color: var(--st-text-secondary);
+    line-height: 1.4;
+  }
+
+  .actions {
+    display: flex;
+    justify-content: center;
+  }
+
+  .primary-btn {
+    width: 100%;
+    max-width: 320px;
+    padding: 12px 24px;
+    background: var(--st-brand);
+    color: #fff;
+    border: none;
+    border-radius: 8px;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s ease;
+  }
+
+  .primary-btn:hover {
+    background: var(--st-brand-dark);
+  }
+</style>

--- a/src/entrypoints/onboarding/steps/Setup.svelte
+++ b/src/entrypoints/onboarding/steps/Setup.svelte
@@ -1,0 +1,750 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { storage } from '#imports';
+  import { browser } from 'wxt/browser';
+  import type { ApiProvider, OpenRouterModel } from '../../../lib/content/types';
+  import { PROVIDER_CONFIG, DEFAULT_PROVIDER } from '../../../lib/content/config';
+
+  interface Props {
+    onNext: () => void;
+    onBack: () => void;
+    onSkip: () => Promise<void>;
+  }
+
+  let { onNext, onBack, onSkip }: Props = $props();
+
+  // Storage items (same pattern as popup)
+  const selectedProviderStorage = storage.defineItem<ApiProvider>('local:selectedProvider', {
+    fallback: 'openrouter',
+  });
+  const selectedModelStorage = storage.defineItem<string>('local:selectedModel', {
+    fallback: 'google/gemini-2.5-flash',
+  });
+  const openRouterKeyStorage = storage.defineItem<string>('local:openRouterKey');
+  const groqSelectedModelStorage = storage.defineItem<string>('local:groqSelectedModel', {
+    fallback: 'llama-3.3-70b-versatile',
+  });
+  const groqKeyStorage = storage.defineItem<string>('local:groqKey');
+  const ollamaSelectedModelStorage = storage.defineItem<string>('local:ollamaSelectedModel', {
+    fallback: 'llama3.2',
+  });
+  const ollamaEndpointStorage = storage.defineItem<string>('local:ollamaEndpoint', {
+    fallback: 'http://localhost:11434',
+  });
+  const hasCompletedOnboardingStorage = storage.defineItem<boolean>(
+    'local:hasCompletedOnboarding',
+    { fallback: false },
+  );
+
+  // Fallback models
+  const OPENROUTER_FALLBACK_MODELS: OpenRouterModel[] = [
+    { id: 'google/gemini-2.5-flash', name: 'Google: Gemini 2.5 Flash', pricing: { prompt: '0.000000075', completion: '0.0000003' } },
+    { id: 'google/gemini-2.0-flash-001', name: 'Google: Gemini 2.0 Flash', pricing: { prompt: '0.000000075', completion: '0.0000003' } },
+    { id: 'openai/gpt-4o-mini', name: 'OpenAI: GPT-4o Mini', pricing: { prompt: '0.00000015', completion: '0.0000006' } },
+  ];
+
+  const GROQ_FALLBACK_MODELS: OpenRouterModel[] = [
+    { id: 'llama-3.3-70b-versatile', name: 'llama-3.3-70b-versatile', pricing: { prompt: '0', completion: '0' } },
+    { id: 'llama-3.1-8b-instant', name: 'llama-3.1-8b-instant', pricing: { prompt: '0', completion: '0' } },
+  ];
+
+  const OLLAMA_FALLBACK_MODELS: OpenRouterModel[] = [
+    { id: 'llama3.2', name: 'llama3.2', pricing: { prompt: '0', completion: '0' } },
+  ];
+
+  function getFallbackModels(provider: ApiProvider): OpenRouterModel[] {
+    if (provider === 'openrouter') return OPENROUTER_FALLBACK_MODELS;
+    if (provider === 'groq') return GROQ_FALLBACK_MODELS;
+    return OLLAMA_FALLBACK_MODELS;
+  }
+
+  // State
+  let selectedProvider = $state<ApiProvider>('openrouter');
+  let selectedModel = $state('google/gemini-2.5-flash');
+  let apiKey = $state('');
+  let ollamaEndpoint = $state('http://localhost:11434');
+  let isSaving = $state(false);
+  let connectionStatus: 'idle' | 'checking' | 'connected' | 'error' = $state('idle');
+  let connectionError = $state('');
+  let connectionModelCount = $state(0);
+
+  // Model combobox state
+  let allModels: OpenRouterModel[] = $state(OPENROUTER_FALLBACK_MODELS);
+  let isLoadingModels = $state(false);
+  let searchQuery = $state('');
+  let isDropdownOpen = $state(false);
+  let highlightedIndex = $state(-1);
+  let comboboxEl: HTMLDivElement | undefined = $state();
+  let listEl: HTMLUListElement | undefined = $state();
+  let inputEl: HTMLInputElement | undefined = $state();
+
+  let providerConfig = $derived(PROVIDER_CONFIG[selectedProvider]);
+  let isOllama = $derived(selectedProvider === 'ollama');
+  let filteredModels = $derived(
+    allModels.filter((m) => {
+      if (!searchQuery) return true;
+      const q = searchQuery.toLowerCase();
+      return m.name.toLowerCase().includes(q) || m.id.toLowerCase().includes(q);
+    }),
+  );
+  let selectedModelDisplay = $derived(
+    allModels.find((m) => m.id === selectedModel)?.name || selectedModel,
+  );
+
+  function openDropdown() {
+    isDropdownOpen = true;
+    searchQuery = '';
+    highlightedIndex = -1;
+  }
+
+  function closeDropdown() {
+    isDropdownOpen = false;
+    searchQuery = '';
+    highlightedIndex = -1;
+  }
+
+  function toggleDropdown() {
+    if (isDropdownOpen) {
+      closeDropdown();
+    } else {
+      openDropdown();
+      setTimeout(() => inputEl?.focus(), 0);
+    }
+  }
+
+  function selectModel(model: OpenRouterModel) {
+    selectedModel = model.id;
+    closeDropdown();
+  }
+
+  function handleSearchInput(event: Event) {
+    searchQuery = (event.target as HTMLInputElement).value;
+    highlightedIndex = -1;
+    if (!isDropdownOpen) isDropdownOpen = true;
+  }
+
+  function handleComboKeydown(event: KeyboardEvent) {
+    if (!isDropdownOpen) {
+      if (event.key === 'ArrowDown' || event.key === 'Enter') {
+        event.preventDefault();
+        openDropdown();
+      }
+      return;
+    }
+
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        highlightedIndex = Math.min(highlightedIndex + 1, filteredModels.length - 1);
+        scrollToHighlighted();
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        highlightedIndex = Math.max(highlightedIndex - 1, 0);
+        scrollToHighlighted();
+        break;
+      case 'Enter':
+        event.preventDefault();
+        if (highlightedIndex >= 0 && highlightedIndex < filteredModels.length) {
+          selectModel(filteredModels[highlightedIndex]);
+        }
+        break;
+      case 'Escape':
+        event.preventDefault();
+        closeDropdown();
+        break;
+    }
+  }
+
+  function scrollToHighlighted() {
+    if (!listEl || highlightedIndex < 0) return;
+    const items = listEl.querySelectorAll('li');
+    if (items[highlightedIndex]) {
+      items[highlightedIndex].scrollIntoView({ block: 'nearest' });
+    }
+  }
+
+  function handleClickOutside(event: MouseEvent) {
+    if (comboboxEl && !comboboxEl.contains(event.target as Node)) {
+      closeDropdown();
+    }
+  }
+
+  async function fetchModels(force = false) {
+    isLoadingModels = true;
+    try {
+      const response = await browser.runtime.sendMessage({
+        action: 'fetchModels',
+        provider: selectedProvider,
+        force,
+      });
+      if (response?.success && response.data?.length > 0) {
+        allModels = response.data;
+        if (!allModels.find((m) => m.id === selectedModel)) {
+          selectedModel = providerConfig.defaultModel;
+        }
+      }
+    } catch (error) {
+      console.error('Failed to fetch models:', error);
+      allModels = getFallbackModels(selectedProvider);
+    } finally {
+      isLoadingModels = false;
+    }
+  }
+
+  function validateApiKey(key: string): { valid: boolean; error?: string } {
+    if (isOllama) return { valid: true };
+    if (!key || key.trim() === '') {
+      return { valid: false, error: 'API key is required' };
+    }
+    if (!providerConfig.keyRegex.test(key.trim())) {
+      return {
+        valid: false,
+        error: `Invalid API key format. ${providerConfig.name} keys should start with ${providerConfig.keyPrefix}`,
+      };
+    }
+    return { valid: true };
+  }
+
+  async function handleProviderChange(event: Event) {
+    const newProvider = (event.target as HTMLSelectElement).value as ApiProvider;
+    selectedProvider = newProvider;
+    const config = PROVIDER_CONFIG[newProvider];
+
+    try {
+      if (newProvider === 'ollama') {
+        selectedModel = (await ollamaSelectedModelStorage.getValue()) || config.defaultModel;
+        ollamaEndpoint = (await ollamaEndpointStorage.getValue()) || 'http://localhost:11434';
+        apiKey = '';
+        connectionStatus = 'idle';
+      } else if (newProvider === 'openrouter') {
+        selectedModel = (await selectedModelStorage.getValue()) || config.defaultModel;
+        apiKey = (await openRouterKeyStorage.getValue()) || '';
+      } else {
+        selectedModel = (await groqSelectedModelStorage.getValue()) || config.defaultModel;
+        apiKey = (await groqKeyStorage.getValue()) || '';
+      }
+    } catch {
+      selectedModel = config.defaultModel;
+      apiKey = '';
+    }
+
+    allModels = getFallbackModels(newProvider);
+    await fetchModels();
+  }
+
+  async function checkOllamaConnection() {
+    connectionStatus = 'checking';
+    connectionError = '';
+    try {
+      await ollamaEndpointStorage.setValue(ollamaEndpoint);
+      const response = await browser.runtime.sendMessage({ action: 'checkOllamaConnection' });
+      if (response?.success) {
+        connectionStatus = 'connected';
+        connectionModelCount = response.modelCount;
+        await fetchModels(true);
+      } else {
+        connectionStatus = 'error';
+        connectionError = response?.error || 'Connection failed';
+      }
+    } catch (error: any) {
+      connectionStatus = 'error';
+      connectionError = error.message || 'Connection failed';
+    }
+  }
+
+  function handleEndpointChange(event: Event) {
+    ollamaEndpoint = (event.target as HTMLInputElement).value;
+    connectionStatus = 'idle';
+  }
+
+  async function saveAndContinue() {
+    isSaving = true;
+    try {
+      if (!isOllama && apiKey && apiKey.trim() !== '') {
+        const validation = validateApiKey(apiKey);
+        if (!validation.valid) {
+          alert(validation.error);
+          isSaving = false;
+          return;
+        }
+      }
+
+      await selectedProviderStorage.setValue(selectedProvider);
+
+      if (selectedProvider === 'ollama') {
+        await ollamaSelectedModelStorage.setValue(selectedModel);
+        await ollamaEndpointStorage.setValue(ollamaEndpoint);
+      } else if (selectedProvider === 'openrouter') {
+        await selectedModelStorage.setValue(selectedModel);
+        await openRouterKeyStorage.setValue(apiKey.trim());
+      } else {
+        await groqSelectedModelStorage.setValue(selectedModel);
+        await groqKeyStorage.setValue(apiKey.trim());
+      }
+
+      await hasCompletedOnboardingStorage.setValue(true);
+      onNext();
+    } catch (error) {
+      console.error('Error saving settings:', error);
+      alert('Failed to save settings. Please try again.');
+    } finally {
+      isSaving = false;
+    }
+  }
+
+  onMount(async () => {
+    try {
+      selectedProvider = (await selectedProviderStorage.getValue()) || DEFAULT_PROVIDER;
+      const config = PROVIDER_CONFIG[selectedProvider];
+
+      if (selectedProvider === 'ollama') {
+        selectedModel = (await ollamaSelectedModelStorage.getValue()) || config.defaultModel;
+        ollamaEndpoint = (await ollamaEndpointStorage.getValue()) || 'http://localhost:11434';
+      } else if (selectedProvider === 'openrouter') {
+        selectedModel = (await selectedModelStorage.getValue()) || config.defaultModel;
+        apiKey = (await openRouterKeyStorage.getValue()) || '';
+      } else {
+        selectedModel = (await groqSelectedModelStorage.getValue()) || config.defaultModel;
+        apiKey = (await groqKeyStorage.getValue()) || '';
+      }
+
+      allModels = getFallbackModels(selectedProvider);
+    } catch (error) {
+      console.error('Error loading settings:', error);
+    }
+
+    await fetchModels();
+    document.addEventListener('click', handleClickOutside);
+  });
+
+  onDestroy(() => {
+    document.removeEventListener('click', handleClickOutside);
+  });
+</script>
+
+<div class="setup">
+  <h2>Configure your provider</h2>
+  <p class="subtitle">Choose an AI provider and enter your credentials to get started.</p>
+
+  <div class="form">
+    <div class="field">
+      <label for="provider-select">API Provider</label>
+      <select
+        id="provider-select"
+        class="select"
+        value={selectedProvider}
+        onchange={handleProviderChange}
+      >
+        <option value="openrouter">OpenRouter</option>
+        <option value="groq">Groq</option>
+        <option value="ollama">Ollama (Local)</option>
+      </select>
+    </div>
+
+    {#if isOllama}
+      <div class="field">
+        <label for="endpoint-input">Ollama Endpoint</label>
+        <input
+          id="endpoint-input"
+          type="text"
+          class="input"
+          placeholder="http://localhost:11434"
+          value={ollamaEndpoint}
+          oninput={handleEndpointChange}
+        />
+        <div class="connection-row">
+          <button
+            class="secondary-btn small"
+            onclick={checkOllamaConnection}
+            disabled={connectionStatus === 'checking'}
+          >
+            {connectionStatus === 'checking' ? 'Checking...' : 'Check Connection'}
+          </button>
+          {#if connectionStatus === 'connected'}
+            <span class="status-text connected">
+              Connected ({connectionModelCount} {connectionModelCount === 1 ? 'model' : 'models'})
+            </span>
+          {:else if connectionStatus === 'error'}
+            <span class="status-text error">{connectionError}</span>
+          {/if}
+        </div>
+      </div>
+    {:else}
+      <div class="field">
+        <label for="api-key-input">{providerConfig.name} API Key</label>
+        <input
+          id="api-key-input"
+          type="password"
+          class="input"
+          placeholder="Enter your {providerConfig.name} API key"
+          value={apiKey}
+          oninput={(e: Event) => { apiKey = (e.target as HTMLInputElement).value; }}
+        />
+        <p class="help-text">
+          Get your API key from <a href={providerConfig.keysUrl} target="_blank">{providerConfig.name}</a>
+        </p>
+      </div>
+    {/if}
+
+    <div class="field">
+      <div class="label-row">
+        <label for="model-search">LLM Model</label>
+        <button class="refresh-btn" onclick={() => fetchModels(true)} disabled={isLoadingModels}>
+          {isLoadingModels ? '...' : 'Refresh'}
+        </button>
+      </div>
+
+      <!-- svelte-ignore a11y_role_has_required_aria_props -->
+      <div class="combobox" bind:this={comboboxEl} role="combobox">
+        <input
+          id="model-search"
+          type="text"
+          class="combobox-input"
+          placeholder="Search models..."
+          value={isDropdownOpen ? searchQuery : selectedModelDisplay}
+          onfocus={openDropdown}
+          oninput={handleSearchInput}
+          onkeydown={handleComboKeydown}
+          bind:this={inputEl}
+        />
+        <button
+          class="combobox-toggle"
+          onclick={toggleDropdown}
+          tabindex="-1"
+          aria-label="Toggle model list"
+        >
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </button>
+
+        {#if isDropdownOpen}
+          <ul class="combobox-list" bind:this={listEl}>
+            {#each filteredModels as model, i (model.id)}
+              <li
+                class:highlighted={i === highlightedIndex}
+                class:selected={model.id === selectedModel}
+                onclick={() => selectModel(model)}
+                onkeydown={(e: KeyboardEvent) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    selectModel(model);
+                  }
+                }}
+                role="option"
+                aria-selected={model.id === selectedModel}
+              >
+                <span class="model-name">{model.name}</span>
+              </li>
+            {/each}
+            {#if filteredModels.length === 0}
+              <li class="no-results">No models found</li>
+            {/if}
+          </ul>
+        {/if}
+      </div>
+    </div>
+  </div>
+
+  <div class="actions">
+    <button class="primary-btn" onclick={saveAndContinue} disabled={isSaving}>
+      {isSaving ? 'Saving...' : 'Save & Continue'}
+    </button>
+    <div class="secondary-actions">
+      <button class="text-btn" onclick={onBack}>Back</button>
+      <button class="text-btn" onclick={onSkip}>Skip</button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .setup {
+    max-width: 480px;
+    margin: 0 auto;
+  }
+
+  h2 {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--st-text);
+    margin-bottom: 6px;
+    text-align: center;
+  }
+
+  .subtitle {
+    font-size: 0.875rem;
+    color: var(--st-text-secondary);
+    text-align: center;
+    margin-bottom: 28px;
+  }
+
+  .form {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    margin-bottom: 28px;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .field label {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--st-text);
+  }
+
+  .label-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .select,
+  .input {
+    width: 100%;
+    padding: 10px 12px;
+    border: 1px solid var(--st-border);
+    border-radius: 8px;
+    font-size: 0.875rem;
+    background: var(--st-bg);
+    color: var(--st-text);
+    font-family: inherit;
+    outline: none;
+    transition: border-color 0.15s ease;
+  }
+
+  .select {
+    appearance: none;
+    background-image: var(--st-select-arrow);
+    background-repeat: no-repeat;
+    background-position: right 12px center;
+    padding-right: 32px;
+  }
+
+  .select:focus,
+  .input:focus {
+    border-color: var(--st-brand);
+    box-shadow: 0 0 0 2px var(--st-brand-surface);
+  }
+
+  .help-text {
+    font-size: 0.75rem;
+    color: var(--st-text-secondary);
+  }
+
+  .help-text a {
+    color: var(--st-brand);
+    text-decoration: none;
+  }
+
+  .help-text a:hover {
+    text-decoration: underline;
+  }
+
+  .connection-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 4px;
+  }
+
+  .status-text {
+    font-size: 0.75rem;
+    font-weight: 500;
+  }
+
+  .status-text.connected {
+    color: var(--st-success);
+  }
+
+  .status-text.error {
+    color: #ef4444;
+  }
+
+  .refresh-btn {
+    background: none;
+    border: none;
+    color: var(--st-brand);
+    font-size: 0.75rem;
+    font-weight: 500;
+    cursor: pointer;
+    padding: 2px 6px;
+  }
+
+  .refresh-btn:hover:not(:disabled) {
+    text-decoration: underline;
+  }
+
+  .refresh-btn:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  /* Combobox */
+  .combobox {
+    position: relative;
+    width: 100%;
+  }
+
+  .combobox-input {
+    width: 100%;
+    padding: 10px 36px 10px 12px;
+    border: 1px solid var(--st-border);
+    border-radius: 8px;
+    font-size: 0.875rem;
+    background: var(--st-bg);
+    color: var(--st-text);
+    font-family: inherit;
+    outline: none;
+    transition: border-color 0.15s ease;
+  }
+
+  .combobox-input:focus {
+    border-color: var(--st-brand);
+    box-shadow: 0 0 0 2px var(--st-brand-surface);
+  }
+
+  .combobox-toggle {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    padding: 4px;
+    cursor: pointer;
+    color: var(--st-text-secondary);
+    display: flex;
+    align-items: center;
+  }
+
+  .combobox-list {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    margin-top: 4px;
+    max-height: 200px;
+    overflow-y: auto;
+    background: var(--st-bg-elevated);
+    border: 1px solid var(--st-border);
+    border-radius: 8px;
+    list-style: none;
+    padding: 4px;
+    z-index: 10;
+    box-shadow: 0 4px 12px var(--st-shadow);
+  }
+
+  .combobox-list li {
+    padding: 8px 10px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.8125rem;
+    color: var(--st-text);
+    transition: background 0.1s ease;
+  }
+
+  .combobox-list li:hover,
+  .combobox-list li.highlighted {
+    background: var(--st-bg-secondary);
+  }
+
+  .combobox-list li.selected {
+    background: var(--st-brand-surface);
+    color: var(--st-brand-text);
+    font-weight: 500;
+  }
+
+  .combobox-list li.no-results {
+    color: var(--st-text-secondary);
+    cursor: default;
+    text-align: center;
+    font-style: italic;
+  }
+
+  .model-name {
+    display: block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .actions {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .primary-btn {
+    width: 100%;
+    padding: 12px 24px;
+    background: var(--st-brand);
+    color: #fff;
+    border: none;
+    border-radius: 8px;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s ease;
+  }
+
+  .primary-btn:hover:not(:disabled) {
+    background: var(--st-brand-dark);
+  }
+
+  .primary-btn:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+
+  .secondary-actions {
+    display: flex;
+    gap: 16px;
+  }
+
+  .secondary-btn {
+    padding: 8px 16px;
+    background: var(--st-bg-secondary);
+    color: var(--st-text);
+    border: 1px solid var(--st-border);
+    border-radius: 6px;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s ease;
+  }
+
+  .secondary-btn.small {
+    padding: 6px 12px;
+    font-size: 0.75rem;
+  }
+
+  .secondary-btn:hover:not(:disabled) {
+    background: var(--st-bg-elevated);
+  }
+
+  .secondary-btn:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  .text-btn {
+    background: none;
+    border: none;
+    color: var(--st-text-secondary);
+    font-size: 0.8125rem;
+    cursor: pointer;
+    padding: 4px 8px;
+    transition: color 0.15s ease;
+  }
+
+  .text-btn:hover {
+    color: var(--st-text);
+  }
+</style>

--- a/src/entrypoints/onboarding/steps/Welcome.svelte
+++ b/src/entrypoints/onboarding/steps/Welcome.svelte
@@ -1,0 +1,190 @@
+<script lang="ts">
+  interface Props {
+    onNext: () => void;
+    onSkip: () => Promise<void>;
+  }
+
+  let { onNext, onSkip }: Props = $props();
+</script>
+
+<div class="welcome">
+  <div class="hero">
+    <img
+      src="/icon/128.png"
+      width="64"
+      height="64"
+      alt="Safetyper"
+      class="logo"
+    />
+    <h1>Welcome to Safetyper</h1>
+    <p class="tagline">Privacy-focused grammar checker that keeps your data safe</p>
+  </div>
+
+  <div class="features">
+    <div class="feature-card">
+      <div class="feature-icon">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </div>
+      <div class="feature-text">
+        <h3>Private by Design</h3>
+        <p>Your text is sent directly to your chosen AI provider. No middleman, no data storage.</p>
+      </div>
+    </div>
+
+    <div class="feature-card">
+      <div class="feature-icon">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </div>
+      <div class="feature-text">
+        <h3>Instant Corrections</h3>
+        <p>Get real-time grammar and spelling fixes as you type across any website.</p>
+      </div>
+    </div>
+
+    <div class="feature-card">
+      <div class="feature-icon">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="2" y="3" width="20" height="14" rx="2" stroke="currentColor" stroke-width="2"/>
+          <path d="M8 21h8M12 17v4" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+        </svg>
+      </div>
+      <div class="feature-text">
+        <h3>Works Everywhere</h3>
+        <p>Compatible with any text field -- emails, documents, social media, and more.</p>
+      </div>
+    </div>
+
+    <div class="feature-card">
+      <div class="feature-icon">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <circle cx="12" cy="12" r="3" stroke="currentColor" stroke-width="2"/>
+          <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.32 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </div>
+      <div class="feature-text">
+        <h3>Choose Your Provider</h3>
+        <p>Use OpenRouter, Groq, or a local Ollama instance -- you're in control.</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="actions">
+    <button class="primary-btn" onclick={onNext}>Get Started</button>
+    <button class="skip-btn" onclick={onSkip}>Skip setup, I'll configure later</button>
+  </div>
+</div>
+
+<style>
+  .welcome {
+    text-align: center;
+  }
+
+  .hero {
+    margin-bottom: 32px;
+  }
+
+  .logo {
+    margin-bottom: 16px;
+    image-rendering: pixelated;
+  }
+
+  h1 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--st-text);
+    margin-bottom: 8px;
+  }
+
+  .tagline {
+    font-size: 0.9375rem;
+    color: var(--st-text-secondary);
+    max-width: 400px;
+    margin: 0 auto;
+  }
+
+  .features {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+    margin-bottom: 32px;
+  }
+
+  .feature-card {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 16px;
+    background: var(--st-bg-secondary);
+    border: 1px solid var(--st-border);
+    border-radius: 10px;
+    text-align: left;
+  }
+
+  .feature-icon {
+    flex-shrink: 0;
+    width: 36px;
+    height: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--st-brand-surface);
+    color: var(--st-brand);
+    border-radius: 8px;
+  }
+
+  .feature-text h3 {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--st-text);
+    margin-bottom: 4px;
+  }
+
+  .feature-text p {
+    font-size: 0.75rem;
+    color: var(--st-text-secondary);
+    line-height: 1.4;
+  }
+
+  .actions {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .primary-btn {
+    width: 100%;
+    max-width: 320px;
+    padding: 12px 24px;
+    background: var(--st-brand);
+    color: #fff;
+    border: none;
+    border-radius: 8px;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s ease;
+  }
+
+  .primary-btn:hover {
+    background: var(--st-brand-dark);
+  }
+
+  .skip-btn {
+    background: none;
+    border: none;
+    color: var(--st-text-secondary);
+    font-size: 0.8125rem;
+    cursor: pointer;
+    padding: 4px 8px;
+    transition: color 0.15s ease;
+  }
+
+  .skip-btn:hover {
+    color: var(--st-text);
+  }
+</style>

--- a/src/lib/content/types.ts
+++ b/src/lib/content/types.ts
@@ -86,6 +86,7 @@ export interface StorageSchema {
   ollamaSelectedModel?: string;
   ollamaCachedModels?: CachedModelsData;
   darkMode?: boolean;
+  hasCompletedOnboarding?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add interactive onboarding wizard that launches on first extension install
- Implement three-step flow: Welcome → Setup → Complete with progress indicator
- Build Welcome step showcasing key features (privacy, instant corrections, universal compatibility, provider choice)
- Create Setup step for API provider selection (OpenRouter, Groq, Ollama) with API key input and model selection via searchable combobox
- Add Complete step with usage instructions and close button
- Implement dark mode toggle for entire onboarding UI
- Track onboarding completion via `hasCompletedOnboarding` storage flag to prevent repeated flows
- Open onboarding page only on first install (via `details.reason === 'install'`)
- Include comprehensive styling with theme variables supporting both light and dark modes

## Technical Details

- New onboarding module at `src/entrypoints/onboarding/` with Svelte components
- Integrated with extension's storage and runtime systems
- Combobox implementation with keyboard navigation and model search/filtering
- API key validation with provider-specific format checking
- Ollama connection testing with endpoint validation
- Background script modified to trigger onboarding on install event