### PR TITLE
feat(config): add custom system prompt and multilingual support

### DIFF
--- a/src/entrypoints/onboarding/App.svelte
+++ b/src/entrypoints/onboarding/App.svelte
@@ -7,7 +7,7 @@
 
   const hasCompletedOnboardingStorage = storage.defineItem<boolean>(
     'local:hasCompletedOnboarding',
-    { fallback: false },
+    { fallback: false }
   );
 
   const darkModeStorage = storage.defineItem<boolean>('local:darkMode', {
@@ -60,14 +60,37 @@
       aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {#if darkMode}
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
           <circle cx="12" cy="12" r="5" stroke="currentColor" stroke-width="2" />
-          <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+          <path
+            d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+          />
         </svg>
         <span>Light</span>
       {:else}
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
         </svg>
         <span>Dark</span>
       {/if}
@@ -76,7 +99,11 @@
 
   <div class="progress-bar">
     {#each [1, 2, 3] as step}
-      <div class="progress-step" class:active={currentStep >= step} class:current={currentStep === step}>
+      <div
+        class="progress-step"
+        class:active={currentStep >= step}
+        class:current={currentStep === step}
+      >
         <div class="step-dot">{step}</div>
         <span class="step-label">
           {#if step === 1}Welcome{:else if step === 2}Setup{:else}Ready{/if}
@@ -161,7 +188,11 @@
     width: 100%;
     min-height: 100vh;
     padding: 0;
-    font-family: Inter, -apple-system, BlinkMacSystemFont, sans-serif;
+    font-family:
+      Inter,
+      -apple-system,
+      BlinkMacSystemFont,
+      sans-serif;
     background: var(--st-bg);
     color: var(--st-text);
   }

--- a/src/entrypoints/onboarding/steps/Complete.svelte
+++ b/src/entrypoints/onboarding/steps/Complete.svelte
@@ -7,8 +7,20 @@
 <div class="complete">
   <div class="hero">
     <div class="checkmark">
-      <svg width="40" height="40" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M20 6L9 17L4 12" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+      <svg
+        width="40"
+        height="40"
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M20 6L9 17L4 12"
+          stroke="currentColor"
+          stroke-width="2.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
       </svg>
     </div>
     <h2>You're all set!</h2>
@@ -20,7 +32,9 @@
       <div class="step-number">1</div>
       <div class="step-content">
         <h3>Click into any text field</h3>
-        <p>Navigate to any website and click on a text input, textarea, or content-editable area.</p>
+        <p>
+          Navigate to any website and click on a text input, textarea, or content-editable area.
+        </p>
       </div>
     </div>
 
@@ -28,7 +42,10 @@
       <div class="step-number">2</div>
       <div class="step-content">
         <h3>Start typing</h3>
-        <p>Write your text naturally. After a brief pause, the Safetyper icon will appear near your cursor.</p>
+        <p>
+          Write your text naturally. After a brief pause, the Safetyper icon will appear near your
+          cursor.
+        </p>
       </div>
     </div>
 
@@ -36,7 +53,10 @@
       <div class="step-number">3</div>
       <div class="step-content">
         <h3>Review corrections</h3>
-        <p>Click the icon to see grammar and spelling suggestions. Accept or dismiss them with one click.</p>
+        <p>
+          Click the icon to see grammar and spelling suggestions. Accept or dismiss them with one
+          click.
+        </p>
       </div>
     </div>
   </div>

--- a/src/entrypoints/onboarding/steps/Setup.svelte
+++ b/src/entrypoints/onboarding/steps/Setup.svelte
@@ -33,19 +33,39 @@
   });
   const hasCompletedOnboardingStorage = storage.defineItem<boolean>(
     'local:hasCompletedOnboarding',
-    { fallback: false },
+    { fallback: false }
   );
 
   // Fallback models
   const OPENROUTER_FALLBACK_MODELS: OpenRouterModel[] = [
-    { id: 'google/gemini-2.5-flash', name: 'Google: Gemini 2.5 Flash', pricing: { prompt: '0.000000075', completion: '0.0000003' } },
-    { id: 'google/gemini-2.0-flash-001', name: 'Google: Gemini 2.0 Flash', pricing: { prompt: '0.000000075', completion: '0.0000003' } },
-    { id: 'openai/gpt-4o-mini', name: 'OpenAI: GPT-4o Mini', pricing: { prompt: '0.00000015', completion: '0.0000006' } },
+    {
+      id: 'google/gemini-2.5-flash',
+      name: 'Google: Gemini 2.5 Flash',
+      pricing: { prompt: '0.000000075', completion: '0.0000003' },
+    },
+    {
+      id: 'google/gemini-2.0-flash-001',
+      name: 'Google: Gemini 2.0 Flash',
+      pricing: { prompt: '0.000000075', completion: '0.0000003' },
+    },
+    {
+      id: 'openai/gpt-4o-mini',
+      name: 'OpenAI: GPT-4o Mini',
+      pricing: { prompt: '0.00000015', completion: '0.0000006' },
+    },
   ];
 
   const GROQ_FALLBACK_MODELS: OpenRouterModel[] = [
-    { id: 'llama-3.3-70b-versatile', name: 'llama-3.3-70b-versatile', pricing: { prompt: '0', completion: '0' } },
-    { id: 'llama-3.1-8b-instant', name: 'llama-3.1-8b-instant', pricing: { prompt: '0', completion: '0' } },
+    {
+      id: 'llama-3.3-70b-versatile',
+      name: 'llama-3.3-70b-versatile',
+      pricing: { prompt: '0', completion: '0' },
+    },
+    {
+      id: 'llama-3.1-8b-instant',
+      name: 'llama-3.1-8b-instant',
+      pricing: { prompt: '0', completion: '0' },
+    },
   ];
 
   const OLLAMA_FALLBACK_MODELS: OpenRouterModel[] = [
@@ -85,10 +105,10 @@
       if (!searchQuery) return true;
       const q = searchQuery.toLowerCase();
       return m.name.toLowerCase().includes(q) || m.id.toLowerCase().includes(q);
-    }),
+    })
   );
   let selectedModelDisplay = $derived(
-    allModels.find((m) => m.id === selectedModel)?.name || selectedModel,
+    allModels.find((m) => m.id === selectedModel)?.name || selectedModel
   );
 
   function openDropdown() {
@@ -363,7 +383,8 @@
           </button>
           {#if connectionStatus === 'connected'}
             <span class="status-text connected">
-              Connected ({connectionModelCount} {connectionModelCount === 1 ? 'model' : 'models'})
+              Connected ({connectionModelCount}
+              {connectionModelCount === 1 ? 'model' : 'models'})
             </span>
           {:else if connectionStatus === 'error'}
             <span class="status-text error">{connectionError}</span>
@@ -379,10 +400,14 @@
           class="input"
           placeholder="Enter your {providerConfig.name} API key"
           value={apiKey}
-          oninput={(e: Event) => { apiKey = (e.target as HTMLInputElement).value; }}
+          oninput={(e: Event) => {
+            apiKey = (e.target as HTMLInputElement).value;
+          }}
         />
         <p class="help-text">
-          Get your API key from <a href={providerConfig.keysUrl} target="_blank">{providerConfig.name}</a>
+          Get your API key from <a href={providerConfig.keysUrl} target="_blank"
+            >{providerConfig.name}</a
+          >
         </p>
       </div>
     {/if}
@@ -414,8 +439,20 @@
           tabindex="-1"
           aria-label="Toggle model list"
         >
-          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 12 12"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3 4.5L6 7.5L9 4.5"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
           </svg>
         </button>
 

--- a/src/entrypoints/onboarding/steps/Welcome.svelte
+++ b/src/entrypoints/onboarding/steps/Welcome.svelte
@@ -9,13 +9,7 @@
 
 <div class="welcome">
   <div class="hero">
-    <img
-      src="/icon/128.png"
-      width="64"
-      height="64"
-      alt="Safetyper"
-      class="logo"
-    />
+    <img src="/icon/128.png" width="64" height="64" alt="Safetyper" class="logo" />
     <h1>Welcome to Safetyper</h1>
     <p class="tagline">Privacy-focused grammar checker that keeps your data safe</p>
   </div>
@@ -23,8 +17,20 @@
   <div class="features">
     <div class="feature-card">
       <div class="feature-icon">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
         </svg>
       </div>
       <div class="feature-text">
@@ -35,8 +41,20 @@
 
     <div class="feature-card">
       <div class="feature-icon">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
         </svg>
       </div>
       <div class="feature-text">
@@ -47,9 +65,15 @@
 
     <div class="feature-card">
       <div class="feature-icon">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <rect x="2" y="3" width="20" height="14" rx="2" stroke="currentColor" stroke-width="2"/>
-          <path d="M8 21h8M12 17v4" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <rect x="2" y="3" width="20" height="14" rx="2" stroke="currentColor" stroke-width="2" />
+          <path d="M8 21h8M12 17v4" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
         </svg>
       </div>
       <div class="feature-text">
@@ -60,9 +84,21 @@
 
     <div class="feature-card">
       <div class="feature-icon">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <circle cx="12" cy="12" r="3" stroke="currentColor" stroke-width="2"/>
-          <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.32 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle cx="12" cy="12" r="3" stroke="currentColor" stroke-width="2" />
+          <path
+            d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.32 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
         </svg>
       </div>
       <div class="feature-text">

--- a/src/entrypoints/popup/App.svelte
+++ b/src/entrypoints/popup/App.svelte
@@ -3,7 +3,11 @@
   import { storage } from '#imports';
   import { browser } from 'wxt/browser';
   import type { ApiProvider, OpenRouterModel } from '../../lib/content/types';
-  import { PROVIDER_CONFIG, DEFAULT_PROVIDER } from '../../lib/content/config';
+  import {
+    PROVIDER_CONFIG,
+    DEFAULT_PROVIDER,
+    DEFAULT_SYSTEM_PROMPT,
+  } from '../../lib/content/config';
 
   const version = browser.runtime.getManifest().version;
 
@@ -33,6 +37,10 @@
 
   const darkModeStorage = storage.defineItem<boolean>('local:darkMode', {
     fallback: false,
+  });
+
+  const customSystemPromptStorage = storage.defineItem<string>('local:customSystemPrompt', {
+    fallback: '',
   });
 
   // Fallback models per provider
@@ -109,6 +117,8 @@
   let connectionStatus: 'idle' | 'checking' | 'connected' | 'error' = 'idle';
   let connectionError = '';
   let connectionModelCount = 0;
+  let customSystemPrompt = '';
+  let showAdvanced = false;
 
   $: providerConfig = PROVIDER_CONFIG[selectedProvider];
   $: showPricing = selectedProvider === 'openrouter';
@@ -287,6 +297,8 @@
         await groqKeyStorage.setValue(apiKey.trim());
       }
 
+      await customSystemPromptStorage.setValue(customSystemPrompt);
+
       showSavedPopup = true;
       setTimeout(() => {
         showSavedPopup = false;
@@ -381,6 +393,10 @@
     connectionStatus = 'idle';
   }
 
+  function resetSystemPrompt() {
+    customSystemPrompt = '';
+  }
+
   function openTestPage() {
     const testUrl = browser.runtime.getURL('/test.html');
     browser.tabs.create({ url: testUrl });
@@ -427,6 +443,7 @@
       }
 
       allModels = getFallbackModels(selectedProvider);
+      customSystemPrompt = (await customSystemPromptStorage.getValue()) || '';
     } catch (error) {
       console.error('Error loading settings:', error);
     }
@@ -658,6 +675,31 @@
       {/if}
 
       <div class="setting-group">
+        <button class="advanced-toggle" onclick={() => (showAdvanced = !showAdvanced)}>
+          {showAdvanced ? '▾' : '▸'} Advanced Settings
+        </button>
+      </div>
+
+      {#if showAdvanced}
+        <div class="setting-group">
+          <div class="label-row">
+            <label for="system-prompt" class="setting-label">System Prompt</label>
+            <button class="refresh-btn" onclick={resetSystemPrompt}>Reset to Default</button>
+          </div>
+          <textarea
+            id="system-prompt"
+            class="system-prompt-input"
+            placeholder={DEFAULT_SYSTEM_PROMPT}
+            bind:value={customSystemPrompt}
+            rows="4"
+          ></textarea>
+          <p class="help-text">
+            Customize the instruction sent to the LLM. Leave empty to use the default prompt.
+          </p>
+        </div>
+      {/if}
+
+      <div class="setting-group">
         <button class="save-button" onclick={saveSettings} disabled={isLoading}>
           {isLoading ? 'Saving...' : 'Save Settings'}
         </button>
@@ -838,6 +880,42 @@
   .refresh-btn:disabled {
     color: var(--st-text-muted);
     cursor: not-allowed;
+  }
+
+  .advanced-toggle {
+    background: none;
+    border: none;
+    color: var(--st-text-secondary);
+    font-size: 0.8125rem;
+    font-weight: 500;
+    font-family: inherit;
+    cursor: pointer;
+    padding: 4px 0;
+    text-align: left;
+  }
+
+  .advanced-toggle:hover {
+    color: var(--st-text);
+  }
+
+  .system-prompt-input {
+    width: 100%;
+    min-height: 80px;
+    padding: 8px 10px;
+    font-size: 0.8125rem;
+    font-family: inherit;
+    color: var(--st-text);
+    background: var(--st-bg-secondary);
+    border: 1px solid var(--st-border);
+    border-radius: 0.375rem;
+    resize: vertical;
+    box-sizing: border-box;
+    line-height: 1.4;
+  }
+
+  .system-prompt-input:focus {
+    outline: none;
+    border-color: var(--st-focus-ring);
   }
 
   /* Combobox */

--- a/src/lib/content/api-client.ts
+++ b/src/lib/content/api-client.ts
@@ -11,7 +11,13 @@ import type {
   CacheEntry,
   ApiCache,
 } from './types';
-import { CACHE_CONFIG, CONFIG, DEFAULT_PROVIDER, PROVIDER_CONFIG } from './config';
+import {
+  CACHE_CONFIG,
+  CONFIG,
+  DEFAULT_PROVIDER,
+  DEFAULT_SYSTEM_PROMPT,
+  PROVIDER_CONFIG,
+} from './config';
 
 /**
  * Simple cache implementation for API responses
@@ -63,8 +69,8 @@ const cache = new SimpleCache();
 /**
  * Generate cache key from text
  */
-function getCacheKey(text: string, model: string): string {
-  return `${model}:${text}`;
+function getCacheKey(text: string, model: string, prompt: string): string {
+  return `${model}:${prompt.substring(0, 32)}:${text}`;
 }
 
 /**
@@ -84,6 +90,7 @@ export async function checkGrammar(text: string): Promise<string> {
     'selectedModel',
     'groqSelectedModel',
     'ollamaSelectedModel',
+    'customSystemPrompt',
   ]);
   const provider: ApiProvider = result.selectedProvider || DEFAULT_PROVIDER;
   let model: string;
@@ -95,8 +102,10 @@ export async function checkGrammar(text: string): Promise<string> {
     model = result.ollamaSelectedModel || PROVIDER_CONFIG.ollama.defaultModel;
   }
 
+  const systemPrompt: string = result.customSystemPrompt || DEFAULT_SYSTEM_PROMPT;
+
   // Check cache first
-  const cacheKey = getCacheKey(text, model);
+  const cacheKey = getCacheKey(text, model, systemPrompt);
   const cachedResult = cache.get(cacheKey);
   if (cachedResult) {
     if (import.meta.env.DEV) {
@@ -111,8 +120,7 @@ export async function checkGrammar(text: string): Promise<string> {
     messages: [
       {
         role: 'system',
-        content:
-          'You are a grammar checking assistant. Fix grammar and spelling errors in the provided text. Return ONLY the corrected text with EXACTLY the same formatting, line breaks, paragraphs, and whitespace as the original. Do not add, remove, or modify any line breaks, indentation, spacing, or paragraph structure. Preserve every newline character and whitespace character exactly as they appear in the original. Do not wrap the response in quotes or add any prefixes or explanations.',
+        content: systemPrompt,
       },
       {
         role: 'user',

--- a/src/lib/content/config.ts
+++ b/src/lib/content/config.ts
@@ -95,6 +95,12 @@ export const PROVIDER_CONFIG = {
 } as const satisfies Record<ApiProvider, object>;
 
 /**
+ * Default system prompt for grammar checking
+ */
+export const DEFAULT_SYSTEM_PROMPT =
+  'You are a grammar checking assistant. Fix grammar and spelling errors in the provided text. IMPORTANT: Always respond in the SAME language as the input text. Do not translate. Return ONLY the corrected text with EXACTLY the same formatting, line breaks, paragraphs, and whitespace as the original. Do not add, remove, or modify any line breaks, indentation, spacing, or paragraph structure. Preserve every newline character and whitespace character exactly as they appear in the original. Do not wrap the response in quotes or add any prefixes or explanations.';
+
+/**
  * Cache configuration
  */
 export const CACHE_CONFIG = {

--- a/src/lib/content/types.ts
+++ b/src/lib/content/types.ts
@@ -87,6 +87,7 @@ export interface StorageSchema {
   ollamaCachedModels?: CachedModelsData;
   darkMode?: boolean;
   hasCompletedOnboarding?: boolean;
+  customSystemPrompt?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Improved default system prompt to explicitly preserve input language ("Always respond in the SAME language as the input text. Do not translate")
- Added configurable system prompt via popup settings with Advanced Settings toggle
- Added Reset to Default button for system prompt
- Updated API client to accept and use custom system prompt from storage
- Cache key now includes prompt signature to differentiate results across different prompts
- Added `customSystemPrompt` storage field to storage schema

## Breaking Changes

None. The feature is backward-compatible — users without a custom prompt will use the improved default.

Closes #1

---

Fixes #1